### PR TITLE
Log Igus motor errors

### DIFF
--- a/aroc/core/state.py
+++ b/aroc/core/state.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Optional
 from drivers.igus_scripts.igus_motor import IgusMotor
+from core.logger import server_logger
 
 from core.configuration import symovo_car_ip, symovo_car_number, igus_motor_ip, igus_motor_port
 from services.robot_lib import XarmClient
@@ -27,6 +28,3 @@ def init_igus_motor(ip, port):
     return
 
 symovo_car.start_polling(interval=10)
-
-
-server_logger = None

--- a/aroc/drivers/igus_scripts/igus_motor.py
+++ b/aroc/drivers/igus_scripts/igus_motor.py
@@ -2,6 +2,7 @@ import threading
 import queue
 import time
 from typing import Callable, Any, Optional, Dict
+from core.logger import server_logger
 
 from drivers.igus_scripts.igus_modbus_driver import (
     init_socket, close, init, set_homing, move, set_reset_faults,
@@ -95,6 +96,7 @@ class IgusMotor:
                     self._last_error = str(e)
                     self._connected = False
                     self._active = False
+                server_logger.log_event('error', f'IgusMotor worker error: {e}')
                 self._reconnect()
                 if cmd.result_queue:
                     cmd.result_queue.put((False, e))

--- a/aroc/routes/api/igus.py
+++ b/aroc/routes/api/igus.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Dict, Any, Optional
+from core.logger import server_logger
 router = APIRouter(prefix="/api/igus", tags=["igus_persistent"])
 
 
@@ -39,6 +40,7 @@ async def move_motor(params: MoveParams):
             "error": igus_motor.get_error(),
         }
     except Exception as e:
+        server_logger.log_event('error', f'move_to_position failed: {e}')
         return {
             "success": False,
             "position": igus_motor._position,
@@ -58,6 +60,7 @@ async def reference_motor():
             "state": igus_motor.get_status()
         }
     except Exception as e:
+        server_logger.log_event('error', f'reference_motor failed: {e}')
         return {
             "success": False,
             "result": None,
@@ -79,6 +82,7 @@ async def reset_faults():
             "state": igus_motor.get_status(),
         }
     except Exception as e:
+        server_logger.log_event('error', f'fault_reset failed: {e}')
         return {
             "success": False,
             "result": None,


### PR DESCRIPTION
## Summary
- wire up global logger in `core.state`
- log errors from the Igus motor worker
- log errors in Igus API handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6840c0dd6038832d88344dff35ce4cca