### PR TITLE
Improve xarm command handling

### DIFF
--- a/aroc/drivers/xarm_scripts/get_position.py
+++ b/aroc/drivers/xarm_scripts/get_position.py
@@ -123,8 +123,8 @@ class RobotMain(object):
         self._arm.release_state_changed_callback(self._state_changed_callback)
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
-        
-        return 'error'
+
+        raise RuntimeError("get_position failed")
 
 
 # arm = XArmAPI('192.168.1.220', baud_checkset=False)

--- a/aroc/drivers/xarm_scripts/get_robot_data.py
+++ b/aroc/drivers/xarm_scripts/get_robot_data.py
@@ -93,8 +93,8 @@ class RobotMain(object):
         self._arm.release_state_changed_callback(self._state_changed_callback)
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
-        
-        return 'error'
+
+        raise RuntimeError("get_robot_data failed")
 
 
 # arm = XArmAPI('192.168.1.220', baud_checkset=False)

--- a/aroc/drivers/xarm_scripts/move_to_pose.py
+++ b/aroc/drivers/xarm_scripts/move_to_pose.py
@@ -130,6 +130,10 @@ class RobotMain(object):
         self._arm.release_state_changed_callback(self._state_changed_callback)
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
+
+        if not result:
+            raise RuntimeError("move_to_pose failed")
+
         return result
 
 

--- a/aroc/drivers/xarm_scripts/move_to_position.py
+++ b/aroc/drivers/xarm_scripts/move_to_position.py
@@ -127,6 +127,10 @@ class RobotMain(object):
         self._arm.release_state_changed_callback(self._state_changed_callback)
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
+
+        if not result:
+            raise RuntimeError("move_to_position failed")
+
         return result
 
 

--- a/aroc/drivers/xarm_scripts/move_tool_position.py
+++ b/aroc/drivers/xarm_scripts/move_tool_position.py
@@ -131,5 +131,9 @@ class RobotMain(object):
         self._arm.release_state_changed_callback(self._state_changed_callback)
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
+
+        if not result:
+            raise RuntimeError("move_tool_position failed")
+
         return result
 

--- a/aroc/drivers/xarm_scripts/put.py
+++ b/aroc/drivers/xarm_scripts/put.py
@@ -119,9 +119,14 @@ class RobotMain(object):
             for i in range(int(1)):
                 if not self.is_alive:
                     break
-                code = self.gripper.deactivate()         
+                code = self.gripper.deactivate()
                 if code == [1, 8, 0, 1, 0, 0, 41, 1, 0, 0, 220]:
-                    return 'success'
+                    result = 'success'
+                else:
+                    result = 'error'
+                if result != 'success':
+                    raise RuntimeError("put failed")
+                return result
                 
         except Exception as e:
             self.pprint('MainException: {}'.format(e))
@@ -130,8 +135,8 @@ class RobotMain(object):
         self._arm.release_state_changed_callback(self._state_changed_callback)
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
-        
-        return 'error'
+
+        raise RuntimeError("put failed")
 
 
 # arm = XArmAPI('192.168.1.220', baud_checkset=False)

--- a/aroc/drivers/xarm_scripts/take.py
+++ b/aroc/drivers/xarm_scripts/take.py
@@ -124,9 +124,12 @@ class RobotMain(object):
                     code = self.gripper.activate()
                     # if not self._check_code(code, 'set_suction_cup'):
                     if code == [1, 8, 0, 1, 0, 0, 41, 1, 0, 0, 220]:
-                        return 'success'
+                        result = 'success'
                     else:
-                        return 'error'
+                        result = 'error'
+                    if result != 'success':
+                        raise RuntimeError("take failed")
+                    return result
                         
                 except:
                     print("suction_error")
@@ -140,6 +143,7 @@ class RobotMain(object):
         if hasattr(self._arm, 'release_count_changed_callback'):
             self._arm.release_count_changed_callback(self._count_changed_callback)
 
+        raise RuntimeError("take failed")
 
 # arm = XArmAPI('192.168.1.220', baud_checkset=False)
 # robot_main = RobotMain(arm)

--- a/aroc/drivers/xarm_scripts/xarm_command_operator.py
+++ b/aroc/drivers/xarm_scripts/xarm_command_operator.py
@@ -1,6 +1,13 @@
 from xarm.wrapper import XArmAPI
-import arduino_controller.arduino_led_controller as als
-from drivers.xarm_scripts import get_robot_data, take, put, move_to_position, get_position, move_tool_position, move_to_pose
+from drivers.xarm_scripts import (
+    get_robot_data,
+    take,
+    put,
+    move_to_position,
+    get_position,
+    move_tool_position,
+    move_to_pose,
+)
 from core.configuration import xarm_manipulator_ip
 import logging
 
@@ -63,7 +70,11 @@ def xarm_command_operator(data):
             
         # Execute command
         result = robot_main.run(data)
-        
+
+        # Normalize result - treat various implementations consistently
+        if result in (False, None, "error"):
+            raise RuntimeError(f"{data['command']} execution failed")
+
         return {
             "success": True,
             "result": result,


### PR DESCRIPTION
## Summary
- fix locking logic for `/api/xarm/command`
- surface command errors to the client
- remove unused import from `xarm_command_operator`
- normalize robot scripts to raise exceptions on failure

## Testing
- `python -m py_compile aroc/drivers/xarm_scripts/xarm_command_operator.py aroc/routes/api/xarm.py aroc/drivers/xarm_scripts/move_to_position.py aroc/drivers/xarm_scripts/move_to_pose.py aroc/drivers/xarm_scripts/move_tool_position.py aroc/drivers/xarm_scripts/take.py aroc/drivers/xarm_scripts/put.py aroc/drivers/xarm_scripts/get_position.py aroc/drivers/xarm_scripts/get_robot_data.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6840c6c08f74832d9028368100b6d92d