### PR TITLE
Add coordinate-based Symovo AGV control

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,56 @@ Starts a new job for the AGV to move to a specified position.
 }
 ```
 
+### Get Maps
+```http
+GET /api/symovo_car/maps
+```
+
+Returns the list of available maps from the AGV.
+
+### Move to Pose
+```http
+POST /api/symovo_car/go_to_pose
+```
+
+Moves the AGV to an arbitrary pose.
+
+**Request Body:**
+```json
+{
+    "x": number,
+    "y": number,
+    "theta": number,
+    "map_id": string,
+    "max_speed": number
+}
+```
+
+**Response:**
+```json
+{
+    "status": "ok",
+    "result": object
+}
+```
+
+### Check Pose
+```http
+POST /api/symovo_car/check_pose
+```
+
+Checks if the given pose is reachable by the AGV.
+
+### Task Status
+```http
+GET /api/symovo_car/task_status
+```
+
+Query Parameters:
+- `task_id` (string, required): Identifier of the task returned when moving the AGV.
+
+Returns status information for the specified task.
+
 ## XArm API
 
 ### Get XArm State

--- a/aroc/docs/API.md
+++ b/aroc/docs/API.md
@@ -191,6 +191,56 @@ Starts a new job for the AGV to move to a specified position.
 }
 ```
 
+### Get Maps
+```http
+GET /api/symovo_car/maps
+```
+
+Returns the list of available maps from the AGV.
+
+### Move to Pose
+```http
+POST /api/symovo_car/go_to_pose
+```
+
+Moves the AGV to an arbitrary pose.
+
+**Request Body:**
+```json
+{
+    "x": number,
+    "y": number,
+    "theta": number,
+    "map_id": string,
+    "max_speed": number
+}
+```
+
+**Response:**
+```json
+{
+    "status": "ok",
+    "result": object
+}
+```
+
+### Check Pose
+```http
+POST /api/symovo_car/check_pose
+```
+
+Checks if the given pose is reachable by the AGV. Returns API response from Symovo.
+
+### Task Status
+```http
+GET /api/symovo_car/task_status
+```
+
+Query Parameters:
+- `task_id` (string, required): Identifier of the task returned when moving the AGV.
+
+Returns status information for the specified task.
+
 ## XArm API
 
 ### Get XArm State

--- a/aroc/routes/api/symovo.py
+++ b/aroc/routes/api/symovo.py
@@ -2,7 +2,16 @@
 
 from fastapi import APIRouter, HTTPException, Query
 from typing import Dict, Any
+from pydantic import BaseModel
 from core.state import symovo_car
+
+
+class MoveToPoseRequest(BaseModel):
+    x: float
+    y: float
+    theta: float = 0
+    map_id: str | None = None
+    max_speed: float | None = None
 
 router = APIRouter(prefix="/api/symovo_car", tags=["symovo"])
 
@@ -55,3 +64,39 @@ def create_new_job(name: str = Query(...)):
         "message": f"Going to position {name}",
         "result": result
     }
+
+
+@router.get("/maps")
+def get_maps():
+    """Return available maps."""
+    maps = symovo_car.get_maps()
+    if maps is None:
+        raise HTTPException(status_code=500, detail="Failed to get maps")
+    return maps
+
+
+@router.post("/go_to_pose")
+def go_to_pose(req: MoveToPoseRequest):
+    """Send AGV to arbitrary pose."""
+    result = symovo_car.move_to(req.x, req.y, req.theta, req.map_id, req.max_speed)
+    if result is None:
+        raise HTTPException(status_code=500, detail="Failed to send move command")
+    return {"status": "ok", "result": result}
+
+
+@router.post("/check_pose")
+def check_pose(req: MoveToPoseRequest):
+    """Check if a pose is reachable."""
+    result = symovo_car.check_reachability(req.x, req.y, req.theta, req.map_id)
+    if result is None:
+        raise HTTPException(status_code=500, detail="Failed to check pose")
+    return result
+
+
+@router.get("/task_status")
+def task_status(task_id: str = Query(...)):
+    """Return status of a task by ID."""
+    result = symovo_car.get_task_status(task_id)
+    if result is None:
+        raise HTTPException(status_code=500, detail="Failed to get task status")
+    return result


### PR DESCRIPTION
## Summary
- extend `AgvClient` with helpers for map retrieval, arbitrary move, pose check and task status
- add matching FastAPI endpoints under `/api/symovo_car`
- document new endpoints in README and API docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6840cde8fe50832d82fa4b7a7408ae8a