### PR TITLE
Add system control router

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This document provides comprehensive documentation for the Robot Control Server 
 - [Igus Motor API](#igus-motor-api)
 - [Symovo AGV API](#symovo-agv-api)
 - [XArm API](#xarm-api)
+- [System API](#system-api)
 - [Error Handling](#error-handling)
 
 ## Base URL
@@ -298,6 +299,62 @@ Executes a command on the XArm robot.
 - 408: Command execution timed out
 - 400: Invalid command
 - 500: Internal server error
+
+## System API
+
+### Get System Status
+```http
+GET /api/system/status
+```
+
+Returns high level information about the robot system.
+
+**Response:**
+```json
+{
+    "symovo_online": boolean,
+    "igus_connected": boolean
+}
+```
+
+### Move to Product
+```http
+POST /api/system/move_to_product
+```
+
+Moves the entire robot system to the specified product location. The AGV drives
+to the coordinates, the lift moves to the given position, and the manipulator
+executes the provided pose sequence.
+
+**Request Body:**
+```json
+{
+    "product_id": "string",
+    "location": {
+        "x": number,
+        "y": number,
+        "theta": number,
+        "map_id": "string"
+    },
+    "lift_position": number,
+    "manipulator_coords": {
+        "x": number,
+        "y": number,
+        "z": number
+    },
+    "angle_speed": number
+}
+```
+
+**Response:**
+```json
+{
+    "status": "ok",
+    "agv_result": object,
+    "lift_result": object,
+    "manipulator_result": object
+}
+```
 
 ## Error Handling
 

--- a/aroc/docs/API.md
+++ b/aroc/docs/API.md
@@ -8,6 +8,7 @@ This document provides comprehensive documentation for the Robot Control Server 
 - [Igus Motor API](#igus-motor-api)
 - [Symovo AGV API](#symovo-agv-api)
 - [XArm API](#xarm-api)
+- [System API](#system-api)
 - [Error Handling](#error-handling)
 
 ## Base URL
@@ -281,6 +282,60 @@ Executes a command on the XArm robot.
 - 408: Command execution timed out
 - 400: Invalid command
 - 500: Internal server error
+
+## System API
+
+### Get System Status
+```http
+GET /api/system/status
+```
+
+Returns high level information about the robot system.
+
+**Response:**
+```json
+{
+    "symovo_online": boolean,
+    "igus_connected": boolean
+}
+```
+
+### Move to Product
+```http
+POST /api/system/move_to_product
+```
+
+Moves the entire robot system to the specified product location.
+
+**Request Body:**
+```json
+{
+    "product_id": "string",
+    "location": {
+        "x": number,
+        "y": number,
+        "theta": number,
+        "map_id": "string"
+    },
+    "lift_position": number,
+    "manipulator_coords": {
+        "x": number,
+        "y": number,
+        "z": number
+    },
+    "angle_speed": number
+}
+```
+
+**Response:**
+```json
+{
+    "status": "ok",
+    "agv_result": object,
+    "lift_result": object,
+    "manipulator_result": object
+}
+```
 
 ## Error Handling
 

--- a/aroc/main.py
+++ b/aroc/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
 
-from routes.api import igus, symovo, xarm
+from routes.api import igus, symovo, xarm, system
 from routes.websocket import ws
 from routes.misc import misc
 from core.configuration import igus_motor_ip, igus_motor_port
@@ -27,6 +27,7 @@ async def lifespan(app: FastAPI):
     app.include_router(igus.router)
     app.include_router(symovo.router)
     app.include_router(xarm.router)
+    app.include_router(system.router)
     app.include_router(ws.router)
     app.include_router(misc.router)
 

--- a/aroc/routes/api/system.py
+++ b/aroc/routes/api/system.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Dict, Any, Optional
+
+from core.state import symovo_car, igus_motor, xarm_client
+
+router = APIRouter(prefix="/api/system", tags=["system"])
+
+class ProductLocation(BaseModel):
+    x: float
+    y: float
+    theta: float = 0
+    map_id: Optional[str] = None
+
+
+class ManipulatorCoords(BaseModel):
+    x: float
+    y: float
+    z: float
+
+
+class SystemMoveRequest(BaseModel):
+    product_id: str
+    location: ProductLocation
+    lift_position: Optional[int] = None
+    manipulator_coords: Optional[ManipulatorCoords] = None
+    angle_speed: float = 20.0
+
+@router.get("/status", response_model=Dict[str, Any])
+def get_system_status():
+    return {
+        "symovo_online": symovo_car.online,
+        "igus_connected": igus_motor.is_connected() if igus_motor else False,
+    }
+
+@router.post("/move_to_product", response_model=Dict[str, Any])
+async def move_to_product(req: SystemMoveRequest):
+    agv_result = symovo_car.move_to(
+        req.location.x,
+        req.location.y,
+        req.location.theta,
+        req.location.map_id,
+    )
+    if agv_result is None:
+        raise HTTPException(status_code=500, detail="Failed to move AGV")
+
+    lift_result = None
+    if req.lift_position is not None and igus_motor:
+        try:
+            lift_result = igus_motor.move_to_position(req.lift_position)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Lift move failed: {e}")
+
+    manip_result = None
+    if req.manipulator_coords:
+        try:
+            manip_result = await xarm_client.move_tool_position(
+                req.manipulator_coords.x,
+                req.manipulator_coords.y,
+                req.manipulator_coords.z,
+                angle_speed=req.angle_speed,
+            )
+            if not manip_result.get("success", False):
+                raise Exception(manip_result.get("error", "Unknown error"))
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Manipulator move failed: {e}")
+
+    return {
+        "status": "ok",
+        "agv_result": agv_result,
+        "lift_result": lift_result,
+        "manipulator_result": manip_result,
+    }
+

--- a/aroc/services/robot_lib.py
+++ b/aroc/services/robot_lib.py
@@ -55,6 +55,20 @@ class XarmClient:
             print(e)
             return None
 
+    async def move_tool_position(self, x: float, y: float, z: float, angle_speed=20):
+        """Move tool by XYZ coordinates relative to the current pose."""
+        try:
+            return await self.execute_command(
+                "move_tool_position",
+                x=x,
+                y=y,
+                z=z,
+                angle_speed=angle_speed,
+            )
+        except Exception as e:
+            print(e)
+            return None
+
 
 import aiohttp
 import asyncio


### PR DESCRIPTION
## Summary
- create `/api/system` router for composite status and driving the AGV to a product location
- include new router in FastAPI startup
- document System API endpoints
- add AGV movement with optional lift/arm control via coordinates

## Testing
- `pytest -q` *(fails: No module named 'websockets', 'xarm')*

------
https://chatgpt.com/codex/tasks/task_e_6840d4011ed4832d93bca3cfae25fc5b