### PR TITLE
Fix igus fault_reset response model

### DIFF
--- a/aroc/routes/api/igus.py
+++ b/aroc/routes/api/igus.py
@@ -69,6 +69,9 @@ async def reference_motor():
 @router.post("/fault_reset", response_model=MotorCommandResponse)
 async def reset_faults():
     response = await _execute_motor_command(igus_motor.fault_reset)
+    # convert bool result to structured form for schema compliance
+    if isinstance(response.get("result"), bool):
+        response["result"] = {"fault_reset": response["result"]}
     return response
 
 


### PR DESCRIPTION
## Summary
- normalize `fault_reset` result to match `MotorCommandResponse`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6846cdbe20c8832dbc3b7ae582ebbcd9