### PR TITLE
Centralize logging

### DIFF
--- a/aroc/core/logger.py
+++ b/aroc/core/logger.py
@@ -56,7 +56,10 @@ class ServerLogger:
                     'message': text.strip()
                 }
                 self.parent.log_history.append(log_entry)
-                
+
+                # Log the message as info
+                self.parent.logger.info(text.strip())
+
                 # Write to original stream
                 if self.stream_type == 'stdout':
                     self.parent.original_stdout.write(text)
@@ -102,5 +105,12 @@ class ServerLogger:
         """Clear log history"""
         self.log_history.clear()
 
-# Create global logger instance
-server_logger = ServerLogger()
+server_logger: Optional[ServerLogger] = None
+
+
+def init_server_logger(max_log_entries: int = 10000) -> ServerLogger:
+    """Initialize global server logger if not already created."""
+    global server_logger
+    if server_logger is None:
+        server_logger = ServerLogger(max_log_entries)
+    return server_logger

--- a/aroc/main.py
+++ b/aroc/main.py
@@ -6,9 +6,13 @@ from contextlib import asynccontextmanager
 from routes.misc import misc
 from core.configuration import igus_motor_ip, igus_motor_port
 from core.connection_config import web_server_host, web_server_port
+from core.logger import init_server_logger, server_logger
 
-import time 
+import time
 # time.sleep(15)
+
+# Initialize logging
+init_server_logger()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -36,7 +40,7 @@ async def lifespan(app: FastAPI):
     app.include_router(ws.router)
     app.include_router(misc.router)
 
-    print("Startup OK.")
+    server_logger.log_event("info", "Startup OK.")
     yield
 
     await xarm_client.__aexit__(None, None, None)


### PR DESCRIPTION
## Summary
- initialize server logger from `main.py`
- forward `print` output to log via `ServerLogger`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_684df8dcd174832d9f66d55b28d43950