### PR TITLE
Centralize logging

### DIFF
--- a/aroc/core/logger.py
+++ b/aroc/core/logger.py
@@ -56,7 +56,10 @@ class ServerLogger:
                     'message': text.strip()
                 }
                 self.parent.log_history.append(log_entry)
-                
+
+                # Log the message as info
+                self.parent.logger.info(text.strip())
+
                 # Write to original stream
                 if self.stream_type == 'stdout':
                     self.parent.original_stdout.write(text)
@@ -102,5 +105,12 @@ class ServerLogger:
         """Clear log history"""
         self.log_history.clear()
 
-# Create global logger instance
-server_logger = ServerLogger()
+server_logger: Optional[ServerLogger] = None
+
+
+def init_server_logger(max_log_entries: int = 10000) -> ServerLogger:
+    """Initialize global server logger if not already created."""
+    global server_logger
+    if server_logger is None:
+        server_logger = ServerLogger(max_log_entries)
+    return server_logger

--- a/aroc/core/state.py
+++ b/aroc/core/state.py
@@ -19,6 +19,7 @@ thread: Optional[threading.Thread] = None
 symovo_car = AgvClient(ip=symovo_car_ip, robot_number=symovo_car_number)
 xarm_client = XarmClient()
 igus_client = IgusClient()
+server_logger.log_event("info", "Hardware clients created")
 
 igus_motor: Optional[IgusMotor] = None
 
@@ -27,13 +28,17 @@ def init_igus_motor(ip, port):
     
     try:
         igus_motor = IgusMotor(ip, port)
-    except:
-        # print(f"[Demo] Ошибка: ")
+        server_logger.log_event("info", "IgusMotor initialized")
+    except Exception as e:
         # if e.args[0] == 'Drive reports FAULT bit set' or e.args[0] == 'Timeout waiting for state OPERATION_ENABLED':
+        from core.logger import server_logger
+        server_logger.log_event("error", f"IgusMotor init failed: {e}")
         try:
             igus_motor._controller.initialize()
-        except:
-            print("error")
+        except Exception as init_err:
+            server_logger.log_event("error", f"Motor re-init failed: {init_err}")
     return
 
 symovo_car.start_polling(interval=10)
+server_logger.log_event("info", "Symovo polling started")
+

--- a/aroc/drivers/igus_scripts/get_robot_data.py
+++ b/aroc/drivers/igus_scripts/get_robot_data.py
@@ -58,11 +58,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def motor(self):

--- a/aroc/drivers/igus_scripts/igus_modbus_driver.py
+++ b/aroc/drivers/igus_scripts/igus_modbus_driver.py
@@ -106,7 +106,8 @@ def send_command(data: bytes) -> bytes:
 def _get_statusword():
     status_bytes = send_command(get_array("status"))
     sw = status_bytes[-2] + (status_bytes[-1] << 8)
-    print(f"[DEBUG] Statusword=0x{sw:x}")
+    from core.logger import server_logger
+    server_logger.log_event("debug", f"Statusword=0x{sw:x}")
     return sw
 
 def get_statusword(status: List[int]) -> Optional[int]:
@@ -128,7 +129,8 @@ def set_shutdown():
         status = send_command(get_array("status"))
         if checkers.is_shutdown(status):
             return
-        print(f'Waiting for shutdown... statusword={hex(get_statusword(status))}')
+        from core.logger import server_logger
+        server_logger.log_event("debug", f"Waiting for shutdown... statusword={hex(get_statusword(status))}")
         time.sleep(0.3)
     raise Exception(f"Shutdown failed, last statusword={hex(get_statusword(status))}")
 
@@ -140,7 +142,8 @@ def set_switch_on():
     status = []
     while not checkers.is_switched_on(status):
         status = send_command(get_array("status"))
-        print('Waiting for switch-on...')
+        from core.logger import server_logger
+        server_logger.log_event("debug", 'Waiting for switch-on...')
         time.sleep(1)
         timer = timer + 1
         if timer > 2:
@@ -163,7 +166,8 @@ def set_reset_faults():
         time.sleep(0.1)
         # 2. Сбросить бит 7 (нормальный controlword, например shutdown)
         send_command(MotorCommandBuilder.shutdown())  # или просто controlword = 0x06 (shutdown)
-        print('Waiting for reset faults... (attempt %d)' % (attempt + 1))
+        from core.logger import server_logger
+        server_logger.log_event("debug", f"Waiting for reset faults... (attempt {attempt + 1})")
         time.sleep(DELAY)
 
     status = send_command(get_array("status"))
@@ -196,7 +200,8 @@ def set_enable_operation():
     status = []
     while not checkers.is_operation_enabled(status):
         status = send_command(get_array("status"))
-        print('Waiting for enabling operation...')
+        from core.logger import server_logger
+        server_logger.log_event("debug", 'Waiting for enabling operation...')
         time.sleep(1)
         timer = timer + 1
         if timer > 2:
@@ -306,7 +311,8 @@ def move(velocity, acceleration, target_position):
             status = send_command(get_array("status"))
             sw = status[-2] + (status[-1] << 8)
             if sw & 0x1000:  # бит 12 выставлен
-                print("[DEBUG] Operation Mode Specific активен, отправляю Enable Operation...")
+                from core.logger import server_logger
+                server_logger.log_event("debug", "Operation Mode Specific активен, отправляю Enable Operation...")
                 send_command(get_array("enable_operation"))
                 time.sleep(0.1)
             else:

--- a/aroc/drivers/igus_scripts/igus_motor.py
+++ b/aroc/drivers/igus_scripts/igus_motor.py
@@ -195,18 +195,19 @@ if __name__ == "__main__":
     motor.home()
 
     while True:
+        from core.logger import server_logger
         try:
             motor.move_to_position(0)
-            print(motor.get_status())
+            server_logger.log_event("info", str(motor.get_status()))
             motor.move_to_position(10000)
-            print(motor.get_status())
-        except:
-            print(f"[Demo] Ошибка: ")
+            server_logger.log_event("info", str(motor.get_status()))
+        except Exception as e:
+            server_logger.log_event("error", f"Move demo failed: {e}")
             # if e.args[0] == 'Drive reports FAULT bit set' or e.args[0] == 'Timeout waiting for state OPERATION_ENABLED':
             try:
-                print(motor.get_status())
+                server_logger.log_event("debug", str(motor.get_status()))
                 motor._controller.initialize()
                 if not motor._controller.is_homed:
                     motor.home()
-            except:
-                print("error")
+            except Exception as init_err:
+                server_logger.log_event("error", f"Init after fail failed: {init_err}")

--- a/aroc/drivers/igus_scripts/machine.py
+++ b/aroc/drivers/igus_scripts/machine.py
@@ -148,6 +148,7 @@ if __name__ == "__main__":
             except:
                 try:
                     fsm.fault_reset()
-                except:
-                    print("error")
+                except Exception as e:
+                    from core.logger import server_logger
+                    server_logger.log_event("error", f"fault_reset failed: {e}")
 

--- a/aroc/drivers/igus_scripts/move_to_position.py
+++ b/aroc/drivers/igus_scripts/move_to_position.py
@@ -63,11 +63,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def motor(self):

--- a/aroc/drivers/igus_scripts/referenciation.py
+++ b/aroc/drivers/igus_scripts/referenciation.py
@@ -59,11 +59,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def motor(self):

--- a/aroc/drivers/igus_scripts/state_reset.py
+++ b/aroc/drivers/igus_scripts/state_reset.py
@@ -58,11 +58,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def motor(self):

--- a/aroc/drivers/igus_scripts/transport.py
+++ b/aroc/drivers/igus_scripts/transport.py
@@ -229,7 +229,8 @@ class ModbusTcpTransport:
             except Exception as e:
                 _LOGGER.warning(f"[heartbeat] Exception in heartbeat: {e}")
             self._heartbeat_stop_event.wait(self._heartbeat_interval or 2.0)
-        print("[heartbeat] Gracefully exited heartbeat loop")
+        from core.logger import server_logger
+        server_logger.log_event("info", "[heartbeat] Gracefully exited heartbeat loop")
 
     def _default_heartbeat_pdu(self) -> bytes:
         """PDU для опроса statusword, сформированный через PacketBuilder."""

--- a/aroc/drivers/xarm_scripts/align.py
+++ b/aroc/drivers/xarm_scripts/align.py
@@ -91,13 +91,16 @@ def process_frames():
                 ws.close()  # Закрываем соединение после получения 10 кадров
 
     def on_error(ws, error):
-        print(f"WebSocket error: {error}")
+        from core.logger import server_logger
+        server_logger.log_event("error", f"WebSocket error: {error}")
     
     def on_close(ws, close_status_code, close_msg):
-        print("WebSocket connection closed")
+        from core.logger import server_logger
+        server_logger.log_event("info", "WebSocket connection closed")
     
     def on_open(ws):
-        print("WebSocket connection opened")
+        from core.logger import server_logger
+        server_logger.log_event("info", "WebSocket connection opened")
     
     # Создание подключения WebSocket
     ws = websocket.WebSocketApp(
@@ -166,11 +169,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/get_position.py
+++ b/aroc/drivers/xarm_scripts/get_position.py
@@ -71,11 +71,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/get_robot_data.py
+++ b/aroc/drivers/xarm_scripts/get_robot_data.py
@@ -44,11 +44,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/measure_test.py
+++ b/aroc/drivers/xarm_scripts/measure_test.py
@@ -137,7 +137,8 @@ def mouse_callback(event, x, y, flags, param):
         start_flag = False
         # Получаем глубину по координатам (y, x)
         depth_value = int(current_depth_image[y, x])
-        print(f"Depth at pixel ({x}, {y}): {depth_value} mm")
+        from core.logger import server_logger
+        server_logger.log_event("info", f"Depth at pixel ({x}, {y}): {depth_value} mm")
 
         # Выделение объекта на основе глубины
         threshold = 10
@@ -163,8 +164,9 @@ def mouse_callback(event, x, y, flags, param):
                 center_x = x + w // 2
                 center_y = y + h // 2
                 center_coordinates = (center_x, center_y)
-                print(object_text)
-                print("Rec Center: "+ str(center_coordinates))
+                from core.logger import server_logger
+                server_logger.log_event("info", object_text)
+                server_logger.log_event("info", "Rec Center: "+ str(center_coordinates))
                 break
 start_flag = False
 async def stream_depth_frames(ws_url):
@@ -177,7 +179,8 @@ async def stream_depth_frames(ws_url):
     cv2.setMouseCallback(window_name, mouse_callback)
 
     async with websockets.connect(ws_url) as websocket:
-        print("Connected to WebSocket server...")
+        from core.logger import server_logger
+        server_logger.log_event("info", "Connected to WebSocket server...")
 
         while True:
             try:
@@ -220,7 +223,8 @@ async def stream_depth_frames(ws_url):
                             start_flag = True
 
                             delta_x_mm, delta_y_mm = calculate_camera_shift(320, 240, center_coordinates[0], center_coordinates[1], depth_image, 380.4253845214844, 380.4253845214844)
-                            print(f"Смещение камеры по X: {delta_x_mm:.2f} мм, по Y: {delta_y_mm:.2f} мм")
+                            from core.logger import server_logger
+                            server_logger.log_event("info", f"Смещение камеры по X: {delta_x_mm:.2f} мм, по Y: {delta_y_mm:.2f} мм")
                             script_path = '/home/boris/web_server/xarm/xarm_scripts/move_tool_position.py'
                             try: 
                                 args = [-delta_y_mm, delta_x_mm, 0]
@@ -248,10 +252,12 @@ async def stream_depth_frames(ws_url):
 
                 # Закрываем окно при нажатии клавиши "q"
                 if cv2.waitKey(1) & 0xFF == ord("q"):
-                    print("Streaming stopped by user.")
+                    from core.logger import server_logger
+                    server_logger.log_event("info", "Streaming stopped by user.")
                     break
             except Exception as e:
-                print(f"Error while receiving data: {e}")
+                from core.logger import server_logger
+                server_logger.log_event("error", f"Error while receiving data: {e}")
                 break
 
     # Закрываем окно OpenCV

--- a/aroc/drivers/xarm_scripts/measure_xy.py
+++ b/aroc/drivers/xarm_scripts/measure_xy.py
@@ -264,7 +264,8 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Ошибка: скрипт ожидает ровно 2 аргумента.")
+        from core.logger import server_logger
+        server_logger.log_event("error", "Ошибка: скрипт ожидает ровно 2 аргумента.")
         sys.exit(1)
     
     try:
@@ -275,7 +276,8 @@ if __name__ == "__main__":
             correct_position = False
 
     except ValueError:
-        print("Ошибка: все аргументы должны быть числами (float).")
+        from core.logger import server_logger
+        server_logger.log_event("error", "Ошибка: все аргументы должны быть числами (float).")
         sys.exit(1)
     stream_depth_frames(correct_position)
     sys.exit(0)

--- a/aroc/drivers/xarm_scripts/move_to_pose.py
+++ b/aroc/drivers/xarm_scripts/move_to_pose.py
@@ -78,11 +78,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/move_to_position.py
+++ b/aroc/drivers/xarm_scripts/move_to_position.py
@@ -77,11 +77,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/move_tool_position.py
+++ b/aroc/drivers/xarm_scripts/move_tool_position.py
@@ -80,11 +80,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/put.py
+++ b/aroc/drivers/xarm_scripts/put.py
@@ -80,11 +80,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/robot_class.py
+++ b/aroc/drivers/xarm_scripts/robot_class.py
@@ -77,11 +77,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/drivers/xarm_scripts/take.py
+++ b/aroc/drivers/xarm_scripts/take.py
@@ -80,11 +80,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):
@@ -131,8 +137,9 @@ class RobotMain(object):
                         raise RuntimeError("take failed")
                     return result
                         
-                except:
-                    print("suction_error")
+                except Exception as e:
+                    from core.logger import server_logger
+                    server_logger.log_event("error", f"suction_error: {e}")
 
 
         except Exception as e:

--- a/aroc/drivers/xarm_scripts/take_from_box.py
+++ b/aroc/drivers/xarm_scripts/take_from_box.py
@@ -103,11 +103,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):
@@ -155,8 +161,9 @@ class RobotMain(object):
                     code = self._arm.set_suction_cup(True, wait=True, delay_sec=0)
                     if not self._check_code(code, 'set_suction_cup'):
                         return
-                except:
-                    print("suction_error")
+                except Exception as e:
+                    from core.logger import server_logger
+                    server_logger.log_event("error", f"suction_error: {e}")
 
                 code = self._arm.set_tool_position(z=-z-50,y=-y,x=-x, radius=0, speed=self._tcp_speed, mvacc=self._tcp_acc, relative=True, wait=True)
                 if not self._check_code(code, 'set_position'):
@@ -186,15 +193,18 @@ correct_j6 = 0
 if __name__ == '__main__':
     try:
         if len(sys.argv) != 6:
-            print("Error: the script expects exactly 5 arguments.")
+            from core.logger import server_logger
+            server_logger.log_event("error", "Error: the script expects exactly 5 arguments.")
             sys.exit(1)
         try:
             x, y, z, w, h = map(float, sys.argv[1:6])
         except ValueError:
-            print("Error: all arguments must be numbers (float).")
+            from core.logger import server_logger
+            server_logger.log_event("error", "Error: all arguments must be numbers (float).")
             sys.exit(1)
 
-        print(f"x = {x}, y = {y}, z = {z},w = {y}, h = {z}")
+        from core.logger import server_logger
+        server_logger.log_event("info", f"x = {x}, y = {y}, z = {z},w = {y}, h = {z}")
         if w > box_w and w < box_h:
             rotate = True
         if h > box_h and h < box_w:

--- a/aroc/drivers/xarm_scripts/take_to_box.py
+++ b/aroc/drivers/xarm_scripts/take_to_box.py
@@ -88,11 +88,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):
@@ -143,8 +149,9 @@ class RobotMain(object):
                     code = self._arm.set_suction_cup(True, wait=True, delay_sec=0)
                     if not self._check_code(code, 'set_suction_cup'):
                         return
-                except:
-                    print("suction_error")
+                except Exception as e:
+                    from core.logger import server_logger
+                    server_logger.log_event("error", f"suction_error: {e}")
 
                 code = self._arm.set_tool_position(z=-z-50,y=-y,x=-x, radius=0, speed=self._tcp_speed, mvacc=self._tcp_acc, relative=True, wait=True)
                 if not self._check_code(code, 'set_position'):

--- a/aroc/drivers/xarm_scripts/test_script.py
+++ b/aroc/drivers/xarm_scripts/test_script.py
@@ -83,11 +83,17 @@ class RobotMain(object):
 
     @staticmethod
     def pprint(*args, **kwargs):
+        from core.logger import server_logger
         try:
             stack_tuple = traceback.extract_stack(limit=2)[0]
-            print('[{}][{}] {}'.format(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())), stack_tuple[1], ' '.join(map(str, args))))
-        except:
-            print(*args, **kwargs)
+            msg = '[{}][{}] {}'.format(
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
+                stack_tuple[1],
+                ' '.join(map(str, args))
+            )
+        except Exception:
+            msg = ' '.join(map(str, args))
+        server_logger.log_event("info", msg)
 
     @property
     def arm(self):

--- a/aroc/main.py
+++ b/aroc/main.py
@@ -6,9 +6,13 @@ from contextlib import asynccontextmanager
 from routes.misc import misc
 from core.configuration import igus_motor_ip, igus_motor_port
 from core.connection_config import web_server_host, web_server_port
+from core.logger import init_server_logger, server_logger
 
-import time 
+import time
 # time.sleep(15)
+
+# Initialize logging
+init_server_logger()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -36,7 +40,7 @@ async def lifespan(app: FastAPI):
     app.include_router(ws.router)
     app.include_router(misc.router)
 
-    print("Startup OK.")
+    server_logger.log_event("info", "Startup OK.")
     yield
 
     await xarm_client.__aexit__(None, None, None)
@@ -52,4 +56,5 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 
 if __name__ == "__main__":
     import uvicorn
+    server_logger.log_event("info", "Starting uvicorn server")
     uvicorn.run("main:app", host=web_server_host, port=web_server_port, reload=True)

--- a/aroc/routes/api/igus.py
+++ b/aroc/routes/api/igus.py
@@ -59,13 +59,13 @@ async def move_motor(params: MoveParams):
         # expose position separately for backward compatibility
         response["result"] = {"position": igus_motor._position}
         return response
-    except:
-        print(f"[Demo] Ошибка: ")
+    except Exception as e:
+        server_logger.log_event("error", f"move_to_position failed: {e}")
         # if e.args[0] == 'Drive reports FAULT bit set' or e.args[0] == 'Timeout waiting for state OPERATION_ENABLED':
         try:
             igus_motor._controller.initialize()
-        except:
-            print("error")
+        except Exception as init_err:
+            server_logger.log_event("error", f"Motor re-init failed: {init_err}")
     return
 
     # expose position separately for backward compatibility
@@ -78,13 +78,13 @@ async def reference_motor():
         response = await _execute_motor_command(igus_motor.home)
         response["result"] = {"homing": igus_motor._homed}
         return response
-    except:
-        print(f"[Demo] Ошибка: ")
+    except Exception as e:
+        server_logger.log_event("error", f"reference_motor failed: {e}")
         # if e.args[0] == 'Drive reports FAULT bit set' or e.args[0] == 'Timeout waiting for state OPERATION_ENABLED':
         try:
             igus_motor._controller.initialize()
-        except:
-            print("error")
+        except Exception as init_err:
+            server_logger.log_event("error", f"Motor re-init failed: {init_err}")
     return
 
 @router.post("/fault_reset", response_model=MotorCommandResponse)

--- a/aroc/services/led_lib.py
+++ b/aroc/services/led_lib.py
@@ -1,6 +1,7 @@
 import requests
 
 from core.connection_config import web_server_ip, web_server_port
+from core.logger import server_logger
 
 ip = web_server_ip
 
@@ -15,12 +16,12 @@ def send_to_arduino(command):
         response = requests.post(url, headers=headers, json=data, verify=False, timeout=2)
         response.raise_for_status()
         response_data = response.json()
-        print("API response:", response_data)
+        server_logger.log_event("info", f"API response: {response_data}")
         return response_data
     except requests.exceptions.RequestException as e:
-        print("Error performing POST request:", e)
+        server_logger.log_event("error", f"Error performing POST request: {e}")
         return False
     except ValueError:
-        print("Error: invalid JSON in response.")
+        server_logger.log_event("error", "Error: invalid JSON in response.")
         return False
     

--- a/aroc/services/robot_lib.py
+++ b/aroc/services/robot_lib.py
@@ -2,6 +2,7 @@
 import aiohttp
 import asyncio
 from typing import List, Dict, Any
+from core.logger import server_logger
 
 from core.connection_config import web_server_ip, web_server_port
 
@@ -38,7 +39,7 @@ class XarmClient:
         try:
             return await self.execute_command("get_current_position")
         except Exception as e:
-            print(e)
+            server_logger.log_event("error", str(e))
 
 
     async def go_to_position(self, positions: List[str], angle_speed=20):
@@ -52,7 +53,7 @@ class XarmClient:
             # The previous implementation attempted to print the exception but
             # omitted the message, effectively swallowing the error.  Log it so
             # that the caller can inspect what went wrong.
-            print(e)
+            server_logger.log_event("error", str(e))
             return None
 
     async def move_tool_position(self, x: float, y: float, z: float, angle_speed=20):
@@ -66,7 +67,7 @@ class XarmClient:
                 angle_speed=angle_speed,
             )
         except Exception as e:
-            print(e)
+            server_logger.log_event("error", str(e))
             return None
 
 

--- a/aroc/services/symovo_lib.py
+++ b/aroc/services/symovo_lib.py
@@ -3,6 +3,7 @@ import time
 import threading
 from datetime import datetime
 import math
+from core.logger import server_logger
 requests.packages.urllib3.disable_warnings()
 # import services.igus_lib as igus_lib
 from core.connection_config import symovo_car_ip, symovo_car_number
@@ -119,11 +120,11 @@ class AgvClient:
 
         except requests.exceptions.RequestException as e:
             # Error during request
-            print(f"Error polling AGV: {e}")
+            server_logger.log_event("error", f"Error polling AGV: {e}")
             self.online = False
         except ValueError:
             # Malformed JSON response
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             self.online = False
 
     def start_polling(self, interval=5):
@@ -157,12 +158,12 @@ class AgvClient:
             return data
         except requests.exceptions.RequestException as e:
             # Error during request
-            print(f"Error polling AGV: {e}")
+            server_logger.log_event("error", f"Error polling AGV: {e}")
             self.online = False
             return False
         except ValueError:
             # Malformed JSON
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             self.online = False
             return False
 
@@ -172,7 +173,7 @@ class AgvClient:
         }
         job_id = job.get('id') 
         if not job_id:
-            print("Error: job does not contain 'id'.")
+            server_logger.log_event("error", "Error: job does not contain 'id'.")
             return False
         url = self._get_transport_url()
         put_create_transport_from_job = f"{url}/create_from_job/{job_id}"
@@ -183,10 +184,10 @@ class AgvClient:
             data = response.json()
             return data
         except requests.exceptions.RequestException as e:
-            print("Error performing PUT request:", e)
+            server_logger.log_event("error", f"Error performing PUT request: {e}")
             return False
         except ValueError:
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             return False
 
     def get_robot_position(self):
@@ -199,12 +200,12 @@ class AgvClient:
             return data["pose"]["x"], data["pose"]["y"]
         except requests.exceptions.RequestException as e:
             # Error during request
-            print(f"Error polling AGV: {e}")
+            server_logger.log_event("error", f"Error polling AGV: {e}")
             self.online = False
             return False
         except ValueError:
             # Malformed JSON
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             self.online = False
             return False
 
@@ -216,12 +217,12 @@ class AgvClient:
             return response.json()
         except requests.exceptions.RequestException as e:
             # Error during request
-            print(f"Error polling AGV: {e}")
+            server_logger.log_event("error", f"Error polling AGV: {e}")
             self.online = False
             return False
         except ValueError:
             # Malformed JSON
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             self.online = False
             return False
 
@@ -233,10 +234,10 @@ class AgvClient:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
-            print(f"Error getting maps: {e}")
+            server_logger.log_event("error", f"Error getting maps: {e}")
             return None
         except ValueError:
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             return None
 
     def move_to(self, x: float, y: float, theta: float = 0, map_id: str | None = None, max_speed: float | None = None):
@@ -253,10 +254,10 @@ class AgvClient:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
-            print(f"Error moving AGV: {e}")
+            server_logger.log_event("error", f"Error moving AGV: {e}")
             return None
         except ValueError:
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             return None
 
     def check_reachability(self, x: float, y: float, theta: float = 0, map_id: str | None = None):
@@ -270,10 +271,10 @@ class AgvClient:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
-            print(f"Error checking reachability: {e}")
+            server_logger.log_event("error", f"Error checking reachability: {e}")
             return None
         except ValueError:
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             return None
 
     def get_task_status(self, task_id: str):
@@ -284,10 +285,10 @@ class AgvClient:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
-            print(f"Error getting task status: {e}")
+            server_logger.log_event("error", f"Error getting task status: {e}")
             return None
         except ValueError:
-            print("Error: invalid JSON in response.")
+            server_logger.log_event("error", "Error: invalid JSON in response.")
             return None
         
     def find_nearest_station(self):
@@ -356,4 +357,4 @@ class AgvClient:
 if __name__ == "__main__":
     client = AgvClient(ip=symovo_car_ip, robot_number=symovo_car_number)
     client.start_polling(interval=10)
-    print(client.go_to_position("Test",True,True))
+    server_logger.log_event("info", str(client.go_to_position("Test", True, True)))

--- a/aroc/utils/ws_proxy.py
+++ b/aroc/utils/ws_proxy.py
@@ -18,7 +18,8 @@ async def forward_messages_fastapi_to_websockets(src_ws: WebSocket, dst_ws: webs
             else:
                 break
     except Exception as e:
-        print("Error (fastapi->websockets):", e)
+        from core.logger import server_logger
+        server_logger.log_event("error", f"fastapi->websockets: {e}")
 
 async def forward_messages_websockets_to_fastapi(src_ws: websockets.WebSocketClientProtocol, dst_ws: WebSocket):
     """
@@ -31,7 +32,8 @@ async def forward_messages_websockets_to_fastapi(src_ws: websockets.WebSocketCli
             else:
                 await dst_ws.send_bytes(msg)
     except Exception as e:
-        print("Error (websockets->fastapi):", e)
+        from core.logger import server_logger
+        server_logger.log_event("error", f"websockets->fastapi: {e}")
 
 async def proxy_websocket(ws: WebSocket, target_url: str):
     """
@@ -45,7 +47,8 @@ async def proxy_websocket(ws: WebSocket, target_url: str):
                 forward_messages_websockets_to_fastapi(target_ws, ws)
             )
     except Exception as e:
-        print(f"WebSocket proxy error: {e}")
+        from core.logger import server_logger
+        server_logger.log_event("error", f"WebSocket proxy error: {e}")
     finally:
         if not ws.client_state.name == "DISCONNECTED":
             await ws.close()


### PR DESCRIPTION
## Summary
- initialize server logger from `main.py`
- forward `print` output to log via `ServerLogger`
- replace scattered prints with `server_logger.log_event`
- improve hardware startup logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_684df8dcd174832d9f66d55b28d43950