### PR TITLE
Show script errors in web UI

### DIFF
--- a/aroc/routes/misc/misc.py
+++ b/aroc/routes/misc/misc.py
@@ -79,12 +79,14 @@ def echo(data: Dict[str, Any]):
 
 @router.post("/run_script")
 async def run_script(data: Dict[str, Any]):
-    """Run a script"""
+    """Run a script and return its result."""
     try:
         if "command" not in data:
             raise HTTPException(status_code=400, detail="No 'command' in JSON")
-        
-        await script_operator(None, data)
-        return True
+
+        result = await script_operator(None, data)
+        return {"status": "ok", "result": result}
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/aroc/static/js/robot.js
+++ b/aroc/static/js/robot.js
@@ -40,18 +40,21 @@ window.robotServer = {
         });
   
         const data = await response.json();
-  
+
         if (!response.ok) {
-          throw new Error(data.error || 'Unknown error');
+          const msg = data.detail || data.error || 'Unknown error';
+          alert('Error: ' + msg);
+          throw new Error(msg);
         }
-  
+
         // Если команда успешно отправлена
         return {
           status: data.status,
-          command: data.command,
+          result: data.result,
         };
       } catch (error) {
         console.error('Ошибка при отправке команды:', error);
+        alert('Error: ' + error.message);
         return { error: error.message };
       }
     }
@@ -87,4 +90,4 @@ window.robotServer = {
   }
   // Инициализируем модуль при загрузке
   window.robotServer.init();
-  
+


### PR DESCRIPTION
## Summary
- raise exceptions from `goToBox1` so error messages propagate
- return script results from `script_operator`
- include result in `/run_script` response and forward exceptions
- display alert with error text when robot script fails on the client

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_684e9de7cf18832daf286f06977e631b