### PR TITLE
Show script errors in modal

### DIFF
--- a/aroc/routes/misc/misc.py
+++ b/aroc/routes/misc/misc.py
@@ -79,12 +79,14 @@ def echo(data: Dict[str, Any]):
 
 @router.post("/run_script")
 async def run_script(data: Dict[str, Any]):
-    """Run a script"""
+    """Run a script and return its result."""
     try:
         if "command" not in data:
             raise HTTPException(status_code=400, detail="No 'command' in JSON")
-        
-        await script_operator(None, data)
-        return True
+
+        result = await script_operator(None, data)
+        return {"status": "ok", "result": result}
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/aroc/static/js/robot.js
+++ b/aroc/static/js/robot.js
@@ -40,18 +40,21 @@ window.robotServer = {
         });
   
         const data = await response.json();
-  
+
         if (!response.ok) {
-          throw new Error(data.error || 'Unknown error');
+          const msg = data.detail || data.error || 'Unknown error';
+          showError(msg);
+          throw new Error(msg);
         }
-  
+
         // Если команда успешно отправлена
         return {
           status: data.status,
-          command: data.command,
+          result: data.result,
         };
       } catch (error) {
         console.error('Ошибка при отправке команды:', error);
+        showError(error.message);
         return { error: error.message };
       }
     }
@@ -81,10 +84,45 @@ window.robotServer = {
         };
       } catch (error) {
         console.error('Ошибка при отправке команды:', error);
+        showError(error.message);
         return { error: error.message };
       }
     }
   }
   // Инициализируем модуль при загрузке
   window.robotServer.init();
-  
+
+  function showError(message) {
+    let modal = document.getElementById('error-modal');
+    if (!modal) {
+      modal = document.createElement('div');
+      modal.id = 'error-modal';
+      modal.style.position = 'fixed';
+      modal.style.top = '0';
+      modal.style.left = '0';
+      modal.style.width = '100%';
+      modal.style.height = '100%';
+      modal.style.display = 'flex';
+      modal.style.alignItems = 'center';
+      modal.style.justifyContent = 'center';
+      modal.style.backgroundColor = 'rgba(0,0,0,0.5)';
+      const box = document.createElement('div');
+      box.style.background = '#fff';
+      box.style.padding = '20px';
+      box.style.borderRadius = '8px';
+      box.style.minWidth = '200px';
+      box.style.textAlign = 'center';
+      const text = document.createElement('div');
+      text.id = 'error-modal-text';
+      text.style.marginBottom = '10px';
+      box.appendChild(text);
+      const btn = document.createElement('button');
+      btn.textContent = 'OK';
+      btn.onclick = () => modal.remove();
+      box.appendChild(btn);
+      modal.appendChild(box);
+      document.body.appendChild(modal);
+    }
+    modal.querySelector('#error-modal-text').textContent = message;
+  }
+


### PR DESCRIPTION
## Summary
- propagate script errors to the client
- present errors in a custom modal with OK button

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_684e9de7cf18832daf286f06977e631b