### PR TITLE
Improve error handling in robot scripts

### DIFF
--- a/aroc/application/robot_scrypts.py
+++ b/aroc/application/robot_scrypts.py
@@ -83,8 +83,22 @@ async def check_devices_ready() -> bool:
             "igus": igus_state,
             "symovo": agv_state,
         }
+        # Compose a short human readable message so that the frontend can
+        # display a clear error instead of "[object Object]".
+        missing = []
+        if not xarm_ready:
+            missing.append("XArm")
+        if not igus_ready:
+            missing.append("Igus")
+        if not agv_ready:
+            missing.append("AGV")
+        message = "{} not ready".format(", ".join(missing)) if missing else "Devices not ready"
+
         logger.error("Device readiness check failed: %s", detail)
-        raise HTTPException(status_code=400, detail=detail)
+        raise HTTPException(
+            status_code=400,
+            detail={"message": message, "states": detail},
+        )
 
     return True
 

--- a/aroc/static/js/robot.js
+++ b/aroc/static/js/robot.js
@@ -42,9 +42,19 @@ window.robotServer = {
         const data = await response.json();
 
         if (!response.ok) {
-          const msg = data.detail || data.error || 'Unknown error';
+          let msg = 'Unknown error';
+          let details = null;
 
-          showError(msg);
+          if (typeof data.detail === 'string') {
+            msg = data.detail;
+          } else if (data.detail && typeof data.detail === 'object') {
+            msg = data.detail.message || msg;
+            details = data.detail.states;
+          } else if (data.error) {
+            msg = data.error;
+          }
+
+          showError(msg, details);
 
           throw new Error(msg);
         }
@@ -77,9 +87,17 @@ window.robotServer = {
         });
   
         const data = await response.json();
-  
+
         if (!response.ok) {
-          throw new Error(data.detail || 'Unknown error');
+          let msg = 'Unknown error';
+
+          if (typeof data.detail === 'string') {
+            msg = data.detail;
+          } else if (data.detail && typeof data.detail === 'object') {
+            msg = data.detail.message || msg;
+          }
+
+          throw new Error(msg);
         }
   
         // Если команда успешно отправлена
@@ -96,7 +114,7 @@ window.robotServer = {
   // Инициализируем модуль при загрузке
   window.robotServer.init();
 
-  function showError(message) {
+  function showError(message, details = null) {
     let modal = document.getElementById('error-modal');
     if (!modal) {
       modal = document.createElement('div');
@@ -120,6 +138,12 @@ window.robotServer = {
       text.id = 'error-modal-text';
       text.style.marginBottom = '10px';
       box.appendChild(text);
+      const detailsEl = document.createElement('pre');
+      detailsEl.id = 'error-modal-details';
+      detailsEl.style.marginBottom = '10px';
+      detailsEl.style.textAlign = 'left';
+      detailsEl.style.display = 'none';
+      box.appendChild(detailsEl);
       const btn = document.createElement('button');
       btn.textContent = 'OK';
       btn.onclick = () => modal.remove();
@@ -128,6 +152,16 @@ window.robotServer = {
       document.body.appendChild(modal);
     }
     modal.querySelector('#error-modal-text').textContent = message;
+    const detailsEl = modal.querySelector('#error-modal-details');
+    if (detailsEl) {
+      if (details) {
+        detailsEl.style.display = 'block';
+        detailsEl.textContent = JSON.stringify(details, null, 2);
+      } else {
+        detailsEl.style.display = 'none';
+        detailsEl.textContent = '';
+      }
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- return readable error messages and device states in `check_devices_ready`
- parse detailed error responses and display them in the browser
- extend error modal to optionally show extra details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_684eb0f19c48832da0ddb870005f8558