### PR TITLE
Fix xarm_command_operator ending newline

### DIFF
--- a/aroc/drivers/xarm_scripts/xarm_command_operator.py
+++ b/aroc/drivers/xarm_scripts/xarm_command_operator.py
@@ -98,10 +98,3 @@ def xarm_command_operator(data):
     finally:
         if arm is not None:
             arm.disconnect()
-
-data= {}
-data["command"] = "move_to_pose"
-data["pose_name"] = "READY_SECTION_CENTER"
-
-result = xarm_command_operator(data)
-#


### PR DESCRIPTION
## Summary
- remove stray debug code from `xarm_command_operator.py`
- ensure file ends with newline

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: websockets)*

------
https://chatgpt.com/codex/tasks/task_e_684edbb2f810832d8b4ecabb539d2db5